### PR TITLE
Update views.py

### DIFF
--- a/status/views.py
+++ b/status/views.py
@@ -166,9 +166,8 @@ def fsregistrations(request, realm=None):
     act = {'unregister': 'Un-Register', 'check_sync': 'Provision', 'reboot': 'Reboot'}
 
     unixts = int(datetime.datetime.now().timestamp())
-    registrations = es.send('api show registrations as json')
-    if registrations:
-        registrations = json.loads(registrations)
+    registrations = json.loads(es.send('api show registrations as json'))
+    if registrations['row_count'] > 0:    
         for i in registrations['rows']:
             if realm == 'all' or realm == i['realm']:
                 sip_profile = i['url'].split('/')[1]


### PR DESCRIPTION
Fix up error when there are zero registrations.

registrations = es.send('api show registrations as json') will always be true as even with no registrations it will be populated with {"row_count": 0}

we can use the row count to determine whether to continue.