### PR TITLE
Code to automate API key generation

### DIFF
--- a/reset-db-to-default.sh
+++ b/reset-db-to-default.sh
@@ -273,6 +273,20 @@ then
     sudo -u django-pbx bash -c 'source ~/envdpbx/bin/activate && cd /home/django-pbx/pbx && python3 manage.py menudefaults --force true'
 fi
 
+###############################################
+# API Key
+###############################################
+pbx_prompt $skip_prompts "Generate an initial API key? "
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    echo ""
+    echo "########################################################"
+    sudo -u django-pbx bash -c 'source ~/envdpbx/bin/activate && cd /home/django-pbx/pbx && python3 manage.py createapikey initial-install'
+    echo "########################################################"
+
+fi
+
+
 
 cd $cwd
 echo " "

--- a/tenants/management/commands/createapikey.py
+++ b/tenants/management/commands/createapikey.py
@@ -1,0 +1,48 @@
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+
+from rest_framework.authtoken.models import Token
+
+UserModel = get_user_model()
+
+
+class Command(BaseCommand):
+    help = 'Create DRF Token for a given user'
+
+    def create_user_token(self, username, reset_token):
+        if username == "initial-install":
+            user = UserModel._default_manager.all().first()
+        else:
+            user = UserModel._default_manager.get_by_natural_key(username)
+
+        if reset_token:
+            Token.objects.filter(user=user).delete()
+
+        token = Token.objects.get_or_create(user=user)
+        self.stdout.write('Generated token {} for user {}'.format(token[0], user))
+        return True
+
+    def add_arguments(self, parser):
+        parser.add_argument('username', type=str)
+
+        parser.add_argument(
+            '-r',
+            '--reset',
+            action='store_true',
+            dest='reset_token',
+            default=False,
+            help='Reset existing User token and create a new one',
+        )
+
+    def handle(self, *args, **options):
+        username = options['username']
+        reset_token = options['reset_token']
+
+        try:
+            token = self.create_user_token(username, reset_token)
+        except UserModel.DoesNotExist:
+            raise CommandError(
+                'Cannot create the Token: user {} does not exist'.format(
+                    username)
+            )
+


### PR DESCRIPTION
The Django Rest Framework comes with a command to generate an API key from CLI, this is a basic modification of that code to allow an API key to be generated for the first user in the database without knowing what that username might be. Then in the reset db command, it also prompts for if you want to create an API key.

As there is a discussion ongoing about the way the user ID is generated, I am picking the first entry from the database as opposed to "user id 1", as we don't know if the first user will definitely be id 1.

There is room for improvement, but this will work for now.